### PR TITLE
Reworked our online resources section

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -19,20 +19,42 @@ title: MontréHack
 
 ## More Challenges
 
-* [RingZer0](http://ringzer0team.com/)
-* [OverTheWire](http://overthewire.org/wargames/)
-* [Smash The Stack](http://smashthestack.org/)
+:star2: represents the best resources according to us
+
+### Jeopardy / Choose your challenge
+
+You decide which challenge you try to solve.
+Like a CTF buffet.
+
+* [RingZer0 Team Online CTF](http://ringzer0team.com/) :star2:
 * [Zenk-Security](http://www.zenk-security.com/)
 * [w3challs](http://w3challs.com/)
 * [Root-Me](http://www.root-me.org/)
 * [NewbieContest](http://www.newbiecontest.org/)
-* [Escape](http://escape.alf.nu/)
-* [Microcorruption](https://microcorruption.com/)
-* [The Matasano Crypto Challenges](http://cryptopals.com/)
-* [Try2hack](http://www.try2hack.nl/)
 * [Microcontest](http://www.microcontest.com/)
-* [Hack-me](http://hack-me.org/)
+
+### Level-ups
+
+You proceed through increasingly difficult challenges that are usually related one to another.
+Very good to develop a deep expertise on a specific topic.
+
+* [Microcorruption](https://microcorruption.com/) :star2: <br/> embedded system exploitation with a custom assembly
+* [The Matasano Crypto Challenges](http://cryptopals.com/) :star2:
+* [OverTheWire](http://overthewire.org/wargames/)
+* [Smash The Stack](http://smashthestack.org/)
+* [alert1 to win](https://alf.nu/alert1) (XSS only)
+* [return true to win](https://alf.nu/ReturnTrue) (Javascript only)
+* [Regex Golf](https://alf.nu/RegexGolf) (Regex only)
+* [Try2Hack](http://www.try2hack.nl/)
 * [Lost Chall](http://lost-chall.org/)
+
+### Open World
+
+These types of challenges usually resembles more what an actual pentest or red team engagement will look like.
+
+* [Hack The Box](https://www.hackthebox.eu/en)
+* [CTF 365](https://ctf365.com/) (free for 30 days then :moneybag:)
+
 
 ## CTF Write-ups
 

--- a/resources.md
+++ b/resources.md
@@ -32,6 +32,7 @@ Like a CTF buffet.
 * [Root-Me](http://www.root-me.org/)
 * [NewbieContest](http://www.newbiecontest.org/)
 * [Microcontest](http://www.microcontest.com/)
+* [pwnable.kr](http://pwnable.kr/)
 
 ### Level-ups
 

--- a/resources.md
+++ b/resources.md
@@ -33,6 +33,7 @@ Like a CTF buffet.
 * [NewbieContest](http://www.newbiecontest.org/)
 * [Microcontest](http://www.microcontest.com/)
 * [pwnable.kr](http://pwnable.kr/)
+* [VulnHub](https://www.vulnhub.com/), many vulnerable VMs
 
 ### Level-ups
 


### PR DESCRIPTION
* Categorized the stuff (jeopardy, level-up and open world)
* Removed non-working links
* Added explanations around the categories
* Added stars (:star2:) on our recommendations

This was triggered when someone asked me what was the best online resource to train for penetration testing and realizing that most non-open-world type online CTFs are not really good for that.

Am I missing something?