### PR TITLE
fixed typo: docket->docker

### DIFF
--- a/_posts/2019-02-20-rop.md
+++ b/_posts/2019-02-20-rop.md
@@ -20,7 +20,7 @@ Le prochain MontréHack portera sur plusieurs challenges ROP!
 
 ## Outils et expérience requis
 
-* Docket ou un Linux 64-bit
+* Docker ou un Linux 64-bit
 * Débogeur (ex: pwndbg, gdb)
 
 ## Où


### PR DESCRIPTION
¯\\_(ツ)_/¯