### PR TITLE
Ajout d'un feed RSS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,3 +15,4 @@ exclude: [ 'README.md', 'CNAME', 'TODO', 'Gemfile', 'Gemfile.lock', 'meta', 'ven
 
 plugins:
   - jemoji
+  - jekyll-feed

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -65,6 +65,7 @@
             <a href="https://twitter.com/montrehack"><i class="fab fa-2x fa-twitter"></i></a>
             <a href="https://www.facebook.com/montrehack"><i class="fab fa-2x fa-facebook-square"></i></a>
             <a href="https://www.linkedin.com/company/montrehack"><i class="fab fa-2x fa-linkedin"></i></a>
+            <a href="/feed.xml"><i class="fas fa-2x fa-rss"></i></a>
           </p>
           <p>
             Archives:


### PR DESCRIPTION
Certains utilisateurs utilisent les flux Atom/RSS pour s'abonner aux
nouvelles des communautés.

Ce patch active le plugin `jekyll-feed` pour le site et ajoute un icône
à la section `Subscribe` afin de permettre et faciliter ce type
d'abonnement.